### PR TITLE
fixed properly defined Spot parameters from always being overwritten

### DIFF
--- a/pymacula/macula.py
+++ b/pymacula/macula.py
@@ -76,10 +76,18 @@ class Spot(object):
 
         #all times are between 0 and 1; should be normalized
         # to actual data time span
-        self.tmax = rand.random()
-        self.lifetime = 1
-        self.ingress = rand.random()
-        self.egress = rand.random()
+        if tmax is None or tmax < 0 or tmax > 1:
+            tmax = rand.random()
+        if lifetime is None or lifetime < 0 or lifetime > 1:
+            lifetime = 1
+        if ingress is None or ingress < 0 or ingress > 1:
+            ingress = rand.random()            
+        if egress is None or egress < 0 or egress > 1:
+            egress = rand.random()  
+        self.tmax = tmax
+        self.lifetime = lifetime
+        self.ingress = ingress
+        self.egress = egress
 
     @property
     def pars(self):


### PR DESCRIPTION
Hi, I noticed some odd behavior when playing with your pymacula code.  Even when I defined the optional tmax, lifetime, ingress, and egress Spot parameters, they were being overwritten with random values in the creation of the Spot objects.  I have made a quick fix to avoid this behavior.

Cheers,
Keaton
