### PR TITLE
Change three occurences of xrange() to range() for compatibility with…

### DIFF
--- a/pymacula/macula.py
+++ b/pymacula/macula.py
@@ -176,9 +176,9 @@ class MaculaModel(object):
             self.star = star
 
         if spots is None:
-            self.spots = [Spot() for i in xrange(nspots)]
+            self.spots = [Spot() for i in range(nspots)]
         elif type(spots) is dict:
-            self.spots = [Spot(**spots) for i in xrange(nspots)]
+            self.spots = [Spot(**spots) for i in range(nspots)]
         else:
             self.spots = spots
 
@@ -203,7 +203,7 @@ class MaculaModel(object):
 
     @property
     def theta_spot(self):
-        theta = np.array([self.spots[i].pars for i in xrange(self.nspots)]).T
+        theta = np.array([self.spots[i].pars for i in range(self.nspots)]).T
 
         #rescale spot times from (0,1) to full data span
         theta[4:, :] *= self.t_span


### PR DESCRIPTION
I just tried to run this basic example on my system under Python 3, which I called `test_pymacula.py`:

```python
#!/usr/bin/env python3

import numpy as np
import matplotlib.pyplot as pl
import pymacula

t = np.arange(0, 500, 0.05)
model = pymacula.MaculaModel()
pl.plot(t, model(t))
pl.show()
```

and ran into the error

```
Traceback (most recent call last):
  File "test_pymacula.py", line 8, in <module>
    model = pymacula.MaculaModel()
  File "/home/wball/pypi/pymacula/pymacula/macula.py", line 179, in __init__
    self.spots = [Spot() for i in xrange(nspots)]
NameError: name 'xrange' is not defined
```

So I replaced three occurences of `xrange` to `range`. This gets the code running under Python 3. I haven't tested under Python 2 but as long as the number of spots is small I don't imagine there's a problem. If there is and you want to preserve Python 2 compatibility we can use a trick like

```python
try:
    range = xrange
except NameError:
    pass
```

or something.